### PR TITLE
Clean metric when KubervisorService is delete

### DIFF
--- a/pkg/controller/item/types.go
+++ b/pkg/controller/item/types.go
@@ -32,7 +32,12 @@ func KubervisorServiceItemKeyFunc(obj interface{}) (string, error) {
 		return "", fmt.Errorf("unable to return the key from obj: %v", obj)
 	}
 
-	return fmt.Sprintf("%s/%s", bci.Namespace(), bci.Name()), nil
+	return GetKey(bci.Namespace(), bci.Name()), nil
+}
+
+// GetKey return Item key from namespace name association
+func GetKey(namespace, name string) string {
+	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
 // Interface item interface


### PR DESCRIPTION
Fixes: #24

When a KubervisorService is deleted the metric gauges that indicate the
number of Pods in each state should be cleaned: Managed, Paused, Breaked